### PR TITLE
[network] Fix 'false positives' in Windows system ping response evaluation

### DIFF
--- a/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
+++ b/bundles/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/utils/NetworkUtils.java
@@ -270,14 +270,13 @@ public class NetworkUtils {
                 throw new IOException("Received no output from ping process.");
             }
             do {
-                if (line.contains("host unreachable") || line.contains("timed out")
-                        || line.contains("could not find host")) {
-                    return false;
+                if (line.contains("TTL=")) {
+                    return true;
                 }
                 line = r.readLine();
             } while (line != null);
 
-            return true;
+            return false;
         }
     }
 


### PR DESCRIPTION
Last changes on evaluation process of ping response on Windows system ping used localized (language dependent) elements of the response to determine ping fails. That lead to false positives on systems not using english language. Replaced this by not localized term "TTL=".

See also discussion here:
https://community.openhab.org/t/oh2-network-binding-device-always-online/21755/46
